### PR TITLE
Changes to let this code work with Kafka Connect 2.11-1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.apache.kafka:connect-api:0.9.0.0"
+    compile "org.apache.kafka:connect-api:0.10.2.0"
     compile "org.slf4j:slf4j-api:1.7.6"
     
     testCompile "junit:junit:4.11"

--- a/src/main/java/org/wushujames/connect/file/FileStreamSinkConnector.java
+++ b/src/main/java/org/wushujames/connect/file/FileStreamSinkConnector.java
@@ -20,6 +20,9 @@ package org.wushujames.connect.file;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +46,18 @@ public class FileStreamSinkConnector extends SinkConnector {
     @Override
     public void start(Map<String, String> props) {
         filename = props.get(FILE_CONFIG);
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        ConfigDef configDef = config();
+        List<ConfigValue> configValues = configDef.validate(connectorConfigs);
+        return new Config(configValues);
     }
 
     @Override

--- a/src/main/java/org/wushujames/connect/file/FileStreamSourceConnector.java
+++ b/src/main/java/org/wushujames/connect/file/FileStreamSourceConnector.java
@@ -21,6 +21,9 @@ import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,6 +54,18 @@ public class FileStreamSourceConnector extends SourceConnector {
             throw new ConnectException("FileStreamSourceConnector configuration must include 'topic' setting");
         if (topic.contains(","))
             throw new ConnectException("FileStreamSourceConnector should only have a single topic when used as a source.");
+    }
+
+    @Override
+    public ConfigDef config() {
+        return new ConfigDef();
+    }
+
+    @Override
+    public Config validate(Map<String, String> connectorConfigs) {
+        ConfigDef configDef = config();
+        List<ConfigValue> configValues = configDef.validate(connectorConfigs);
+        return new Config(configValues);
     }
 
     @Override


### PR DESCRIPTION
The updated Kafka Connect code expects that Connectors will implement config and validate functions, which this code does not.

If you want to run this kafka-connector-skeleton with recent versions of Kafka Connect (downloaded directly from Confluent, like the 2.11-1.0.0 package), you must use a JAR build from code that implements these functions.

This changeset adds these functions.